### PR TITLE
Support channel names being pulled from affiliate names when name isnt available

### DIFF
--- a/zap2xml.pl
+++ b/zap2xml.pl
@@ -1173,7 +1173,7 @@ sub parseTVGGrid {
         if (!defined($stations{$cs}{stnNum})) {
             $stations{$cs}{stnNum} = $src;
             $stations{$cs}{number} = $num;
-            $stations{$cs}{name} = $cjs->{'Name'};
+            $stations{$cs}{name} = $cjs->{'Name'} || $cjs->{'affiliateName'};
             if (defined($cjs->{'FullName'}) && $cjs->{'FullName'} ne $cjs->{'Name'}) {
                 if ($cjs->{'FullName'} ne '') {
                     $stations{$cs}{fullname} = $cjs->{'FullName'};


### PR DESCRIPTION
Example from my cache file

```
zcat /volume1/Apps/zap2xml/cache/1727913600000.js.gz | jq '.channels[0] | { callSign, affiliateName, affiliateCallSign, channelId, channelNo }'
{
  "callSign": "CBUTDT",
  "affiliateName": "CANADIAN BROADCASTING CORPORATION",
  "affiliateCallSign": "null",
  "channelId": "51981",
  "channelNo": "2.1"
}
```